### PR TITLE
Add build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the application
+        run: npm run build


### PR DESCRIPTION
# Changes
- Adds a build script
  - This just preps the environment and runs `npm build`. If it fails to build, there's been a compilation error of some sort and the pipeline will fail

I _was_ going to add [Prettier](https://github.com/prettier/prettier) to the project by using [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier#user-content-recommended-configuration) (CRA already includes ESLint so all we need to do is extend the `eslintConfig` in package.json) but I think it'd be counter-productive without a bunch of extra configuration that I don't want to do. First off, it prefers double-quotes everywhere which isn't really all that standard with React. In fact, `create-react-app`'s generated project actually contains a mix of single and double quotes, making it fail the lint before any code is actually written by a human. On top of that, the linter causes _errors_ when Prettier is upset which will fail the build pipeline. This is just gonna be annoying. If the code gets too messy or we feel we want to enforce a code style across the frontend codebase, we can try this again.