### PR TITLE
Start adding some login-related API stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "beacon-city": "^0.1.6",
         "jquery": "^3.6.0",
         "react": "^17.0.2",
+        "react-countdown-hook": "^1.1.1",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
+        "react-use": "^17.3.2",
         "web-vitals": "^2.1.4"
       }
     },
@@ -3384,6 +3386,11 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -3850,6 +3857,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -5201,6 +5213,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
@@ -5339,6 +5359,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.3"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "node_modules/css-loader": {
@@ -5683,6 +5712,11 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "node_modules/csstype": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7126,6 +7160,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -8023,6 +8067,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8153,6 +8202,14 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
+      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
+      "dependencies": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -8514,6 +8571,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -10319,6 +10384,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10901,6 +10971,50 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "node_modules/nano-css": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
+      "integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
+      "dependencies": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/nano-css/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/nano-css/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
+    "node_modules/nano-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.2.0",
@@ -12828,6 +12942,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-countdown-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-countdown-hook/-/react-countdown-hook-1.1.1.tgz",
+      "integrity": "sha512-+/vH6zK2H0yM9dPWJOa3hnLsBWWjwwi/6KOXDBc6F65lrc8vmuMozjTOlLhG4AtyyOTJAd2bvJhlph8IPqrXxg==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -13072,6 +13194,40 @@
         }
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.3.2.tgz",
+      "integrity": "sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0",
+        "react-dom": "^16.8.0  || ^17.0.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13259,6 +13415,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -13458,6 +13619,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
+      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13568,6 +13737,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/select-hose": {
@@ -13715,6 +13895,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
       }
     },
     "node_modules/setprototypeof": {
@@ -13904,6 +14092,14 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "dependencies": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -13927,6 +14123,33 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -14139,6 +14362,11 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -14545,6 +14773,14 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w=="
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -14578,6 +14814,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -14623,6 +14864,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.12.0",
@@ -18176,6 +18422,11 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -18539,6 +18790,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -19562,6 +19818,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "3.20.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.3.tgz",
@@ -19659,6 +19923,15 @@
       "integrity": "sha512-0gDYWEKaGacwxCqvQ3Ypg6wGdD1AztbMm5h1JsactG2hP2eiflj808QITmuWBpE7sjSEVrAlZhPTVd/nNMj/hQ==",
       "requires": {
         "postcss-selector-parser": "^6.0.8"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -19890,6 +20163,11 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         }
       }
+    },
+    "csstype": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -20961,6 +21239,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -21600,6 +21888,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -21690,6 +21983,14 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "inline-style-prefixer": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
+      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -21922,6 +22223,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -23232,6 +23538,11 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -23670,6 +23981,42 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nano-css": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
+      "integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
+      "requires": {
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "nanoid": {
       "version": "3.2.0",
@@ -24939,6 +25286,12 @@
         "whatwg-fetch": "^3.6.2"
       }
     },
+    "react-countdown-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-countdown-hook/-/react-countdown-hook-1.1.1.tgz",
+      "integrity": "sha512-+/vH6zK2H0yM9dPWJOa3hnLsBWWjwwi/6KOXDBc6F65lrc8vmuMozjTOlLhG4AtyyOTJAd2bvJhlph8IPqrXxg==",
+      "requires": {}
+    },
     "react-dev-utils": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.0.tgz",
@@ -25122,6 +25475,33 @@
         "workbox-webpack-plugin": "^6.4.1"
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "requires": {}
+    },
+    "react-use": {
+      "version": "17.3.2",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.3.2.tgz",
+      "integrity": "sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==",
+      "requires": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.3.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -25267,6 +25647,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -25398,6 +25783,14 @@
         }
       }
     },
+    "rtl-css-js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
+      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -25461,6 +25854,11 @@
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "select-hose": {
       "version": "2.0.0",
@@ -25593,6 +25991,11 @@
         "parseurl": "~1.3.3",
         "send": "0.17.2"
       }
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -25747,6 +26150,14 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -25766,6 +26177,32 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "statuses": {
       "version": "1.5.0",
@@ -25911,6 +26348,11 @@
         "browserslist": "^4.16.6",
         "postcss-selector-parser": "^6.0.4"
       }
+    },
+    "stylis": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -26200,6 +26642,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w=="
     },
+    "throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
+    },
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -26227,6 +26674,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.1",
@@ -26262,6 +26714,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "tsconfig-paths": {
       "version": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "beacon-city": "^0.1.6",
     "jquery": "^3.6.0",
     "react": "^17.0.2",
+    "react-countdown-hook": "^1.1.1",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
+    "react-use": "^17.3.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/AppRoutes.js
+++ b/src/AppRoutes.js
@@ -1,14 +1,30 @@
-import {Route, Routes} from "react-router-dom";
+import {createSearchParams, Navigate, Route, Routes, useLocation} from "react-router-dom";
 import {Towers} from "./routes/towers";
 import {Channels} from "./routes/channels";
 import {Messages} from "./routes/messages";
 import {UserDetails} from "./routes/user"
+import {SignInContext} from "./context/signInContext";
+import {useContext} from "react";
+import {LoginPage} from "./routes/LoginPage";
 
 export const AppRoutes = (props) => <Routes>
-    <Route path="/" element={<Towers/>}>
+    <Route path="/login" element={<LoginPage/>}/>
+    <Route path="/" element={
+        // https://reactrouter.com/docs/en/v6/upgrading/v5#refactor-custom-routes
+        <RequireAuth redirectTo="/login">
+            <Towers/>
+        </RequireAuth>
+    }>
         <Route path="/channels/:towerId" element={<Channels/>}>
             <Route path=":channelId" element={<Messages/>}/>
         </Route>
         <Route path="/me" element={<UserDetails/>}/>
     </Route>
 </Routes>;
+
+function RequireAuth({children, redirectTo}) {
+    const {signedIn} = useContext(SignInContext);
+    const loc = useLocation();
+    const params = createSearchParams({resumePath: loc.pathname, resumeSearch: loc.search});
+    return signedIn ? children : <Navigate to={redirectTo + '?' + params}/>;
+}

--- a/src/context/signInContext.js
+++ b/src/context/signInContext.js
@@ -1,0 +1,62 @@
+import {createContext, useState} from "react";
+import {DefaultConfig} from "../util/CISApiHelper";
+import {BASE_PATH, CityManagementApi, Configuration} from "beacon-central-identity-server";
+import {useLocalStorage} from "react-use";
+
+const basePath = (DefaultConfig.basePath ?? BASE_PATH);
+
+export const SignInContext = createContext({
+    signedIn: false,
+    attemptSignIn: (username, password) => console.log('WARNING: Attempted to sign in but hit a no-op function. This means that the SignInContext was never set up properly!!!'),
+});
+
+export function SignInContextProvider({children}) {
+    const [signedIn, setSignedIn] = useLocalStorage('signedIn', false);
+    const [signInInProgress, setSignInInProgress] = useState(false);
+    const attemptSignIn = (username, password) => signInWithCredentials(username, password, signInInProgress, setSignInInProgress, setSignedIn);
+
+    return (
+        <SignInContext.Provider value={{
+            signedIn: signedIn,
+            attemptSignIn: attemptSignIn,
+            // setCredentials: setCredentials,
+            signInInProgress: signInInProgress,
+        }}>
+            {children}
+        </SignInContext.Provider>
+    );
+}
+
+function signInWithCredentials(username, password, signInInProgress, setSignInInProgress, setSignedIn) {
+    console.log('Attempting to sign in');
+    if (signInInProgress) {
+        console.log('Attempted to sign in while there was already another attempt in progress. This attempt has been cancelled.');
+        setSignInInProgress(true);
+    }
+    let configuration = new Configuration({
+        basePath: basePath,
+        credentials: 'include',
+        username: username,
+        password: password,
+    });
+    /*
+     TODO: Listing the cities isn't necessarily what needs to happen here. All that needs to happen is an API request
+      has to be sent with the correct credentials. An endpoint like /check-authentication will be added to both services
+      in the near future. Upon sending ANY request to the API, authenticated or not, the server will give the browser
+      a JSESSIONID cookie. This cookie will be sent to the server with every request. If the browser had sent a request
+      with the correct credentials, then there is no need to continue to send credentials in subsequent requests as the
+      server will know that this is the same, authenticated client by the JSESSIONID it was assigned.
+    */
+    new CityManagementApi(configuration).listRegisteredCities().then(value => {
+        console.log('Sign in succeeded');
+        setSignedIn(true);
+        setSignInInProgress(false);
+    }).catch(reason => {
+        setSignedIn(false);
+        setSignInInProgress(false);
+        if (reason instanceof Response) {
+            reason.json().then(value => console.log(value));
+        }
+        console.log('Sign in failed.');
+    });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,16 @@ import reportWebVitals from './reportWebVitals';
 import {BrowserRouter} from "react-router-dom";
 import {AppRoutes} from './AppRoutes';
 import {TowerContextProvider} from "./context/towerContext";
+import {SignInContextProvider} from "./context/signInContext";
 
 ReactDOM.render(
     <React.StrictMode>
         <BrowserRouter>
-            <TowerContextProvider>
-                <AppRoutes/>
-            </TowerContextProvider>
+            <SignInContextProvider>
+                <TowerContextProvider>
+                    <AppRoutes/>
+                </TowerContextProvider>
+            </SignInContextProvider>
         </BrowserRouter>
     </React.StrictMode>,
     document.getElementById('root')

--- a/src/routes/LoginPage.js
+++ b/src/routes/LoginPage.js
@@ -1,0 +1,74 @@
+import React, {useContext, useEffect, useState} from "react";
+import {SignInContext} from "../context/signInContext";
+import {Navigate, useSearchParams} from "react-router-dom";
+import useCountDown from "react-countdown-hook";
+
+export const LoginPage = (props, context) => {
+    const initialTime = 5 * 1000; // initial time in milliseconds, defaults to 60000
+    const interval = 1000; // interval to change remaining time amount, defaults to 1000
+    const {signedIn, attemptSignIn} = useContext(SignInContext);
+    const [searchParams] = useSearchParams();
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const referringQueryParameters = searchParams.get('resumeSearch') ?? '';
+    // If the user navigated to the login page themselves (along with some other edge cases), this the path could be null. Default to the base URL in that case.
+    const referringPath = searchParams.get('resumePath') ?? '/';
+    // A string that hold the original path the user was at before they were redirected to the login page.
+    // The original query parameters are also preserved and are appended to the referring path if they exist.
+    const redirectToAfterLoginSuccess = (referringPath + (referringQueryParameters ? '?' + referringQueryParameters : ''));
+    const [readyToRedirect, setReadyToRedirect] = useState(false);
+    const [timeLeft, {start}] = useCountDown(initialTime, interval);
+    // The timeLeft value starts at 0 which makes testing for 0 in a useEffect useless .-.
+    const [countdownInProgress, setCountdownInProgress] = useState(false);
+
+    const tryCredentials = (event) => {
+        attemptSignIn(username, password);
+        // Without this, the page reloads for some weird reason.
+        // See https://reactjs.org/docs/forms.html#controlled-components
+        event.preventDefault();
+    };
+
+    useEffect(() => {
+        if (signedIn) {
+            setCountdownInProgress(true);
+            start();
+        }
+    }, [signedIn, start]);
+
+    useEffect(() => {
+        // The "you will be redirected" countdown has reached zero
+        if (countdownInProgress && timeLeft === 0) {
+            // Set a variable that'll cause the <Navigate> component to become visible.
+            setReadyToRedirect(true);
+        }
+    }, [countdownInProgress, timeLeft]);
+
+    return (
+        <div className='userDetailsPane'>
+            <div className='userDetails'>{signedIn ?
+                <div style={{flexDirection: 'column'}}>
+                    <div>You're already signed in!</div>
+                    <div>Redirecting back to "{redirectToAfterLoginSuccess}" in {timeLeft / 1000} seconds...</div>
+                    {readyToRedirect ?
+                        // Same as <Redirect> in React Router v5
+                        <Navigate to={redirectToAfterLoginSuccess}/> : <></>}
+                </div> :
+                <>
+                    <div>Not signed in!</div>
+                    <form onSubmit={tryCredentials}>
+                        <label>
+                            Username:
+                            <input type="text" value={username} onChange={event => setUsername(event.target.value)}/>
+                        </label>
+                        <label>
+                            Password:
+                            <input type="password" value={password}
+                                   onChange={event => setPassword(event.target.value)}/>
+                        </label>
+                        <button type="submit">Submit</button>
+                    </form>
+                </>}
+            </div>
+        </div>
+    );
+};

--- a/src/routes/LoginPage.js
+++ b/src/routes/LoginPage.js
@@ -44,8 +44,8 @@ export const LoginPage = (props, context) => {
     }, [countdownInProgress, timeLeft]);
 
     return (
-        <div className='userDetailsPane'>
-            <div className='userDetails'>{signedIn ?
+        <div id='loginPane'>
+            <div id='loginField'>{signedIn ?
                 <div style={{flexDirection: 'column'}}>
                     <div>You're already signed in!</div>
                     <div>Redirecting back to "{redirectToAfterLoginSuccess}" in {timeLeft / 1000} seconds...</div>
@@ -54,17 +54,10 @@ export const LoginPage = (props, context) => {
                         <Navigate to={redirectToAfterLoginSuccess}/> : <></>}
                 </div> :
                 <>
-                    <div>Not signed in!</div>
+                    <h1>Sign in</h1>
                     <form onSubmit={tryCredentials}>
-                        <label>
-                            Username:
-                            <input type="text" value={username} onChange={event => setUsername(event.target.value)}/>
-                        </label>
-                        <label>
-                            Password:
-                            <input type="password" value={password}
-                                   onChange={event => setPassword(event.target.value)}/>
-                        </label>
+                        <input type="text" placeholder="Username" value={username} onChange={event => setUsername(event.target.value)}/>
+                        <input type="password" placeholder="Password" value={password} onChange={event => setPassword(event.target.value)}/>
                         <button type="submit">Submit</button>
                     </form>
                 </>}

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -5,9 +5,9 @@ export const UserDetails = (props) => {
     return (
         <div className='userDetailsPane'>
             <div className='userDetails'>
-				<span className='username'>Username</span>
-				<img alt="Your Avatar" src={default_avatar}/>
-			</div>
+                <span className='username'>Username</span>
+                <img alt="Your Avatar" src={default_avatar}/>
+            </div>
         </div>
     );
-}
+};

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -166,3 +166,67 @@ body {
   font-weight: bolder;
   font-size: 3em;
 }
+
+/* Log in page */
+#loginPane {
+  width: 100%;
+  height: 100%;
+  background-color: #404040;
+  color: white;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#loginField {
+  background-color: #54524A;
+  border-radius: 32px;
+  box-shadow: inset 0 0 3px black;
+  box-sizing: border-box;
+
+  width: 50%;
+  height: 50%;
+
+  padding: 32px;
+}
+
+#loginField form {
+  width: 100%;
+}
+
+#loginField input {
+  display: block;
+  border: none;
+  padding: 8px;
+  margin: 8px;
+  border-radius: 12px;
+  font-size: 1em;
+
+  background-color: #cac7bb;
+  box-shadow: inset 0 0 3px black;
+
+  width: 75%;
+  box-sizing: border-box;
+}
+#loginField button {
+  padding: 12px;
+  margin: 8px;
+  float:right;
+  font-size: 1em;
+
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 0 2px black;
+
+  background-color: #cac7bb;
+
+  transition: 0.1s;
+}
+#loginField button:hover {
+  background-color: #FFD800;
+  transition: 0.1s;
+}
+#loginField button:hover:after {
+  content: " >";
+}

--- a/src/util/CISApiHelper.js
+++ b/src/util/CISApiHelper.js
@@ -1,15 +1,15 @@
 import {AccountManagementApi, CityManagementApi, Configuration} from "beacon-central-identity-server";
 
 // eslint-disable-next-line
+const LOCAL_URL = "http://localhost:9876";
+// eslint-disable-next-line
 const QA_URL = "https://beacon-cis-main-staging.herokuapp.com";
 // eslint-disable-next-line
 const PROD_URL = "https://beacon-cis-main-staging.herokuapp.com";
-// eslint-disable-next-line
-const LOCAL_URL = "http://localhost:9876";
 
 // Is of type ConfigurationParameters
 export const DefaultConfig = {
-    basePath: LOCAL_URL,
+    basePath: QA_URL,
 };
 
 export const AccountManagementHelper = new AccountManagementApi(new Configuration(DefaultConfig));

--- a/src/util/CISApiHelper.js
+++ b/src/util/CISApiHelper.js
@@ -1,7 +1,10 @@
 import {AccountManagementApi, CityManagementApi, Configuration} from "beacon-central-identity-server";
 
+// eslint-disable-next-line
 const QA_URL = "https://beacon-cis-main-staging.herokuapp.com";
+// eslint-disable-next-line
 const PROD_URL = "https://beacon-cis-main-staging.herokuapp.com";
+// eslint-disable-next-line
 const LOCAL_URL = "http://localhost:9876";
 
 // Is of type ConfigurationParameters

--- a/src/util/CISApiHelper.js
+++ b/src/util/CISApiHelper.js
@@ -1,0 +1,13 @@
+import {AccountManagementApi, CityManagementApi, Configuration} from "beacon-central-identity-server";
+
+const QA_URL = "https://beacon-cis-main-staging.herokuapp.com";
+const PROD_URL = "https://beacon-cis-main-staging.herokuapp.com";
+const LOCAL_URL = "http://localhost:9876";
+
+// Is of type ConfigurationParameters
+export const DefaultConfig = {
+    basePath: LOCAL_URL,
+};
+
+export const AccountManagementHelper = new AccountManagementApi(new Configuration(DefaultConfig));
+export const CityManagementHelper = new CityManagementApi(new Configuration(DefaultConfig));


### PR DESCRIPTION
The purpose of this PR is not for feeding real data into the frontend. This is the big hurdle before that's possible. To do that, we'd need credentials. I figured I might as well make a sign-in system so that we can have that in place and ready for the other changes we'll make down the line.

## Changes
- AppRoutes
  - AppRoutes now has a /login route that displays the LoginPage Component.
  - The "/" route has the component that it _would_ return wrapped in a new RequireAuth component. This forces the RequireAuth function to evaluate whether the user is signed in.
    - React Router is impatient though, so I can't involve any `async` operations (i.e. promise-based functions like those that would actually check the API for whether the user is authenticated)
    - Instead of checking the API, we grab a variable from SignInContext (which is persisted via local storage) which we set to true after a successful sign-in
    - So that we don't constantly have a variable in the context always telling us we're sign in, the variable will have to be set to false at some point. I think what we should do is have it get set to false upon ___any___ API call returning with a 401 status code. If the `signedIn` context variable gets changed to false and the user attempts to navigate anywhere, they'll be directed to the LoginPage component.
- LoginPage
  - I was going to stuff this stuff inside `user.js` but I figured it being its own page would be much more sensible.
  - This is a somewhat overcomplicated login page. It allows you to log into the CIS with a username and password.
- CISApiHelper
  - This currently serves no purpose. It's just an example on how to instantiate one of the API libraries. ___Beware___ of what specific class you're instantiating as it may be for the CIS or a City. Naturally, it'll matter whether you configure it with the url of the CIS or some random City. If you're not sure whether the class is for the CIS or City, check the OpenAPI documentation on the deployed Heroku apps. There's one `XYZApi` class for each of the collapsable groupings on the rendered Swagger page. 


### Important note
The LoginPage, as it stands, is strictly for logging into the CIS. I still need to figure out a way to make sure we also authenticate with the City. I think what should be done is when `signInWithCredentials()` succeeds, the credentials used will be stored in the SignInContext. These credentials will then be used for requests to any City that the client might interact with. 

## TODO
- ~~Add at least one way that the frontend will pull real data. This will provide an opportunity for the client to invalidate the `signedIn` local storage variable and prompt the user to log in again. Without this, the app will always think it's logged in despite 401s coming from the server~~
- Fix the `JSESSIONID` cookie from the server being blocked by the browser because it came from a different origin.
- I've decided that, to fetch real data, I'm gonna start by using a proper state management library. As such, this PR will become too noisy and include too much that is out of its original scope. This PR should be merged because its purpose is mostly fulfilled. A subsequent PR will fix the rest of the login/logout issues, add some basic state management, and fetch a bit of real data.
  - To do the login/logout stuff properly, I'll probably just store the users credentials in local storage. It's literally a sin in the corporate space to do something so stupidly insecure but it's quick and easy and this is meant to be a demo project, not a hardened piece of software. It just needs to work... ;-;
  - I'll just have the logout button clear local storage so the app has no credentials to continue sending to the City instances or the CIS. We probably won't even end up relying on the `JSESSIONID` cookie since we won't know if we'll need to send creds or not for a request to a given City because we'll have no clue if we have a cookie establishing a session with it yet