### PR TITLE
Fixed message scrolling issues

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -178,6 +178,17 @@ body {
   padding-left: 1em;
   border-radius: 1em;
 }
+.messageAlert {
+  text-align: center;
+  color: white;
+  background-color:#a7942d;
+  padding: 4px;
+  cursor: pointer;
+}
+.messageAlert:hover {
+  background-color: #FFD800;
+  color: black;
+}
 
 .selected::before {
   font-style: italic;


### PR DESCRIPTION
The message pane now scrolls to the bottom on page load/when a new message is sent, and the user is already at the bottom. I started implementing a 'more messages below' popup, but it didn't work as intended so I'm leaving the skeleton code in but not implementing functionality for it, for now.