### PR TITLE
Fix channels not loading when switching Towers

### DIFF
--- a/src/components/TowerDetails.js
+++ b/src/components/TowerDetails.js
@@ -1,11 +1,12 @@
-import React, { useContext } from 'react';
+import React, {useContext, useEffect} from 'react';
 import {observer} from "mobx-react-lite";
-import {useEffectOnce} from "react-use";
 import {TowerContext} from "../context/towerContext";
 
 export const TowerDetails = observer(function TowerDetails(props) {
-    // Load channels of a Tower when viewing that tower. useEffectOnce runs when the component is mounted.
-    useEffectOnce(() => props.tower.refreshChannels());
+    // Load channels of a Tower when viewing that Tower
+    useEffect(() => {
+        props.tower.initializeChannels();
+    }, [props.tower]);
 
     const {generateInviteCode} = useContext(TowerContext);
 

--- a/src/observables/ObservableTower.js
+++ b/src/observables/ObservableTower.js
@@ -27,37 +27,28 @@ export class ObservableTower {
         this.member_account_ids = observable.array(member_account_ids);
     }
 
-    * refreshChannels() {
-        console.log(`Refreshing channels for tower ${this.id}.`);
-        const channelsIdsBeforeRefresh = Array.from(this.channels.keys());
-        const channelIdsFromBackend = [];
-        // TODO: Find a way to lock this flow from being called if it is already pending for this tower
-        try {
-            const channels = yield new ChannelsApi(this.cityConfig(this.id)).getChannels({towerId: this.id});
-            channels.forEach(channel => {
-                channelIdsFromBackend.push(channel.id);
-                // If we already know about this channel
-                if (this.channels.has(channel.id)) {
-                    // Update channel info (UI will only refresh if this data (like the channel name) is new)
-                    const existingChannel = this.channels.get(channel.id);
-                    existingChannel.name = channel.name;
-                    existingChannel.order = channel.order;
-                } else {
-                    // Add this as a new channel
+    /**
+     * Initializes the channels for this Tower if necessary. If the channels map for this Tower is not empty,
+     * this will not be run again.
+     */
+    * initializeChannels() {
+        // Only initialize the channels list if there are none right now
+        if (this.channels.size === 0) {
+            console.log(`Refreshing channels for tower ${this.id}.`);
+            // TODO: Find a way to lock this flow from being called if it is already pending for this tower
+            try {
+                const channels = yield new ChannelsApi(this.cityConfig(this.id)).getChannels({towerId: this.id});
+                channels.forEach(channel => {
                     this.channels.set(channel.id, new ObservableChannel(this.cityConfig, channel.id, channel.towerId, channel.name, channel.order));
-                }
-            });
-        } catch (error) {
-            // TODO: Make this a snackbar with notistack
-            //  see https://github.com/iamhosseindhv/notistack
-            console.log(`fetchMessages error: ${error}`);
-            throw error;
+                });
+            } catch (error) {
+                // TODO: Make this a snackbar with notistack
+                //  see https://github.com/iamhosseindhv/notistack
+                console.log(`fetchMessages error: ${error}`);
+                throw error;
+            }
+            console.log(`Finished refreshing channels for tower ${this.id}.`);
         }
-        // Delete all channels that are present in our Map but don't exist in the list the backend returned
-        channelsIdsBeforeRefresh
-            .filter(channelId => !channelIdsFromBackend.includes(channelId))
-            .forEach(idOfChannelToDelete => this.channels.delete(idOfChannelToDelete));
-        console.log(`Finished refreshing channels for tower ${this.id}.`);
     }
 
     handleChannelCreated(channel) {


### PR DESCRIPTION
As it turns out, the `useEffectOnce` was truly only being called once! Now we have a `useEffect` which depends on the Tower that is passed in. Should that Tower change, the hook will be called again should the Tower that is being viewed change.

Also, the `refreshChannels` flow has been renamed to `initializeChannels` to better reflect its purpose. It will only run once for a given Tower so that we aren't needlessly sending a request every time the user switches Towers.