### PR TITLE
Use mars/create-react-app buildpack for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "buildpacks": [
+    {
+      "url": "mars/create-react-app"
+    }
+  ]
+}


### PR DESCRIPTION
Doing this for [beacon-frontend-main-staging](https://beacon-frontend-main-staging.herokuapp.com/) app fixed it crashing all the time. It was previously using herokuapp/node for the buildpack.

See:
https://blog.heroku.com/deploying-react-with-zero-configuration
https://github.com/mars/create-react-app-buildpack#usage